### PR TITLE
Add more hint to silver sponsor

### DIFF
--- a/src/components/DiamondSponsor.vue
+++ b/src/components/DiamondSponsor.vue
@@ -10,7 +10,7 @@
         <div class="columns small-12 medium-6">
           <div class="word">
             <h6>{{ sponsor.name }}</h6>
-            <p>
+            <p class="description">
               {{{ sponsor.desc }}}
             </p>
             <a href="#" class="moreBtn" @click="openMore">{{conf.more}}</a>

--- a/src/components/SilverSponsor.vue
+++ b/src/components/SilverSponsor.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="columns small-6 sponsor-wrapper silver">
+  <div class="columns small-6 sponsor-wrapper silver" v-bind:class="sponsor.more == 'true' ? 'more' : ''">
     <div class="sponsor">
       <div class="word">
         <h6 class="text-center">{{ sponsor.name }}</h6>
@@ -8,6 +8,10 @@
         <div class="photo" :style="sponsorImg">
         </div>
       </a>
+      <p class="description">
+        {{{ sponsor.desc }}}
+      </p>
+      <a href="#" class="moreBtn" @click="openMore">{{conf.more}}</a>
     </div>
   </div>
 </template>
@@ -20,6 +24,11 @@
         'background-image': 'url(' + @sponsor.photo + ')'
       }
     props: ['sponsor']
+    methods: {
+      openMore: (event) ->
+        event.preventDefault()
+        $(event.target).parents('.silver').removeClass('more')
+      }
 </script>
 
 <style lang="sass?indentedSyntax" type="text/sass" scoped>

--- a/src/components/Sponsor.vue
+++ b/src/components/Sponsor.vue
@@ -58,10 +58,35 @@
         text-align: justify
       .moreBtn
         display: none
-    .diamond.more
-      .word p
-        height: 6.5rem
+    .more
+      position: relative;
+      p.description
+        height: 0rem
         overflow: hidden
       .moreBtn
         display: block
+        position: absolute;
+        width: 1.5em;
+        height: 1.5em;
+        right: 0.6rem;
+        bottom: 0;
+        overflow: hidden;
+        text-indent: -999em;
+        background-color: $primary-color;
+        box-shadow: inset 0 0 5px rgba(black, 0.7);
+        &:after
+          content: ' ';
+          position: absolute;
+          width: 100%;
+          height: 100%;
+          top: -50%;
+          left: -50%;
+          transform: rotate(45deg) scale(1.4);
+          background-color: white;
+          box-shadow: 0 0 5px rgba(black, 0.7);
+    .diamond.more
+      p.description
+        height: 6.5rem;
+      .moreBtn
+        right: 1.4rem;
 </style>


### PR DESCRIPTION
調整贊助商的顯示，把 `more` 改為小按鈕放置在右下角。
增加對 Silver 等級贊助商的介紹支援。

![2016-10-09 8 05 17](https://cloud.githubusercontent.com/assets/887984/19220262/e5471726-8e5b-11e6-9cfc-1e656827c878.png)
